### PR TITLE
feat: add `POST` endpoint for creating watchlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ This also includes a RESTful CRUD API for the following resources:
   - [x] `GET`: Retrieve the anime resource given the associated anime id. Also include any associated resources associated with this anime and an authenticated user (user ratings, watch status, watchlists added)
   - [x] `PATCH`: (_protected_) Update anime status associated with the user (ratings, watch status)
   - [x] `DELETE`: (_protected_) Remove anime status associated with the user (ratings, watch status)
-- [ ] `/api/watchlists`
+- [x] `/api/watchlists`
   - [x] `GET`: Search and return a collection of public watchlists, given query parameters. For an authenticated user, this would include any private watchlists for that specific user as well.
-  - [ ] `POST`: (_protected_) Create a new watchlist.
+  - [x] `POST`: (_protected_) Create a new watchlist.
 - [ ] `/api/watchlists/:watchlistId`
   - [x] `GET`: Retrieve the watchlist resource given the associated watchlist id.
   - [ ] `PUT`: (_protected_) Update the watchlist metadata (name, description, public)

--- a/src/app/(api)/api/watchlists/route.ts
+++ b/src/app/(api)/api/watchlists/route.ts
@@ -105,16 +105,16 @@ export async function POST(request: NextRequest) {
 
   const { title, description, isPublic } = body.data
 
-  const { error, status } = await supabase.from('watchlists').insert({
+  const result = await supabase.from('watchlists').insert({
     title,
     description,
     is_public: isPublic,
     user_id: user.id,
   })
 
-  if (error) {
-    console.error(error)
-    return NextResponse.json('Failed to create watchlist', { status })
+  if (result.error) {
+    console.error(result)
+    return NextResponse.json('Failed to create watchlist', { status: result.status })
   }
 
   return NextResponse.json({ title, description, isPublic, userId: user.id }, { status: 201 })

--- a/src/app/(api)/api/watchlists/schemas.ts
+++ b/src/app/(api)/api/watchlists/schemas.ts
@@ -9,3 +9,9 @@ export const searchWatchlistsQueryParamsSchema = z.object({
   page: z.coerce.number().int('Page must be an integer'),
   limit: z.coerce.number().int('Limit must be an integer'),
 })
+
+export const watchlistRequestBodySchema = z.object({
+  title: z.string().min(1).max(100),
+  description: z.string().max(4000),
+  isPublic: z.boolean(),
+})

--- a/supabase/migrations/20240525172504_remote_schema.sql
+++ b/supabase/migrations/20240525172504_remote_schema.sql
@@ -1,0 +1,16 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.add_default_owner()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+begin
+  insert into public.watchlists_users (watchlist_id, user_id, role)
+  values (new.id, new.user_id, 'owner');
+  return new;
+end;
+$function$
+;
+
+

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -50,12 +50,14 @@ CREATE TYPE "public"."watch_status" AS ENUM (
 ALTER TYPE "public"."watch_status" OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."add_default_owner"() RETURNS "trigger"
-    LANGUAGE "plpgsql"
-    AS $$begin
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $$
+begin
   insert into public.watchlists_users (watchlist_id, user_id, role)
   values (new.id, new.user_id, 'owner');
   return new;
-end;$$;
+end;
+$$;
 
 ALTER FUNCTION "public"."add_default_owner"() OWNER TO "postgres";
 


### PR DESCRIPTION
### Acceptance Criteria:
- [x] A new POST endpoint exists for watchlists `api/watchlists`
   - Accepts a json request body with `title`, `description`, `isPublic`
- [x] Checks user is logged in
- [x] Fields for watchlist creation are validated
   - `title`: min 1 char, max 100 char
   - `description`: max 4000 char
   - `isPublic`: is boolean
- [x] Tested through Postman

